### PR TITLE
Add notready event

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -47,14 +47,20 @@ namespace("Cylon.Adaptors", function() {
       this.connector.on('notReady', function(data) {
         Logger.error("Connecting to Skynet adaptor: '" + _this.name + "' FAILED...");
         Logger.error("Check UUID and Token are correct and try again");
+        callback(null);
         _this.connection.emit('notReady', data);
       });
 
-      this.defineAdaptorEvent('ready');
+      this.connector.on('ready', function(data) {
+        callback(null);
+        _this.connection.emit('ready', data);
+      });
 
-      this.defineAdaptorEvent('message');
+      this.connector.on('message', function(data){
+        Logger.info('Message Received');
+        _this.connection.emit('message', data);
+      });
 
-      callback(null);
     };
 
     Skynet.prototype.message = function(data) {


### PR DESCRIPTION
Adds notReady event to adaptor so we can detect incorrect logging credentials.
